### PR TITLE
Create naive container for message handling

### DIFF
--- a/klaxer/models.py
+++ b/klaxer/models.py
@@ -43,6 +43,27 @@ class Alert:
         return cls(service_name, **TRANSFORMERS[service_name](data))
 
 
+class NaiveContainer:
+    """Holds any values you give to it and retrieves them safely."""
+    def __init__(self, *args, **kwargs):
+        if len(args) > 0:
+            raise TypeError('NaiveContainer does not accept positional arguments')
+        for kwarg in kwargs:
+            setattr(self, kwarg, kwargs[kwarg])
+
+    def __getattr__(self, name):
+        return
+
+
+class Message(NaiveContainer):
+    """Naively holds attributes from a Slack message due to dynamic rendering."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def __repr__(self):
+        return '<%s.%s>' % (self.__class__.__name__, self.id)
+
+
 @transformer('sensu')
 def transform_sensu(data):
     """Decompose a sensu alert into arguments for an alert"""

--- a/klaxer/sinks.py
+++ b/klaxer/sinks.py
@@ -10,12 +10,10 @@ from datetime import datetime
 from slacker import Slacker
 
 from klaxer import config, errors
-from klaxer.models import Severity
+from klaxer.models import Severity, Message
 
 Channel = namedtuple('Channel', ['id', 'name'])
 User = namedtuple('User', ['id', 'name', 'handle'])
-Message = namedtuple('Message', ['attachments', 'icons', 'ts', 'user', 'username', 'text', 'type', 'bot_id', 'bot_link', 'subtype'])
-Message.__new__.__defaults__ = (None,) * len(Message._fields)
 
 # Regex pattern for text ending with dup indicators (e.g. "(x2)")
 debounce_pattern = r'\(x(?P<count>\d+)\)$'


### PR DESCRIPTION
Adds a `NaiveContainer` that has safe gets for missing attributes and makes `Message`s use this instead of the `namedtuple`. 

This keeps us from chasing the immutability concept with a data model that seems to be highly dynamic. The `namedtuple` stays intact for `Channel` and `User`.

Resolves #9 